### PR TITLE
Remove `global.conf` because cannot override it.

### DIFF
--- a/global.conf
+++ b/global.conf
@@ -1,2 +1,0 @@
-# Set the media directory based on the PHP constant set in `setup.php`
-ca_media_root_dir = __RWAHS_MEDIA_DIR__/<app_name>


### PR DESCRIPTION
This will be achieved using a symlink created on deployment
