### PR TITLE
Add `type_id` to related lookups for objects and occurrences

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -1,3 +1,8 @@
+# ----------------------------
+# Related item lookup settings
+# ----------------------------
+ca_occurrences_lookup_settings = [^ca_occurrences.preferred_labels (^ca_occurrences.type_id)]
+ca_objects_lookup_settings = [<unit relativeTo='ca_objects'>^ca_object_representations.media.icon (^ca_objects.idno - ^ca_objects.type_id) ^ca_objects.preferred_labels</unit>]
 # -------------------------
 # Currency settings
 # -------------------------


### PR DESCRIPTION
- This gives the user a bit more context when doing the lookup.
