### PR TITLE
Tweak settings for "typed list" fields.

### DIFF
--- a/conf/services.conf
+++ b/conf/services.conf
@@ -54,7 +54,7 @@ simple_api_endpoints = {
             object_id = ^ca_objects.object_id,
             idno = ^ca_objects.idno,
             Title = ^ca_objects.preferred_labels,
-            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;CreatorType&quot;: &quot;^CreatorType&quot;", "&quot;Name&quot;: &quot;^Name&quot;</unit>"}]",
+            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^Name&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
             DateOfCreation = ^ca_objects.DateOfCreation,
             Publisher = ^ca_objects.Publisher,
             DateOfPublication = ^ca_objects.DateOfPublication,
@@ -72,7 +72,7 @@ simple_api_endpoints = {
             object_id = ^ca_objects.object_id,
             idno = ^ca_objects.idno,
             Title = ^ca_objects.preferred_labels,
-            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;CreatorType&quot;: &quot;^CreatorType&quot;", "&quot;Name&quot;: &quot;^Name&quot;</unit>"}]",
+            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^Name&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
             DateOfCreation = ^ca_objects.DateOfCreation,
             Publisher = ^ca_objects.Publisher,
             DateOfPublication = ^ca_objects.DateOfPublication,
@@ -81,8 +81,7 @@ simple_api_endpoints = {
             PhysicalDescription = ^ca_objects.PhysicalDescription,
             Subjects = "["<unit relativeTo="ca_occurrences" delimiter="," restrictToTypes="subject">&quot;^preferred_labels&quot;</unit>"]",
             Summary = ^ca_objects.Summary,
-            Notes = ^ca_objects.Notes,
-            TermsOfUse = ^ca_objects.TermsOfUse
+            Notes = ^ca_objects.Notes
         }
     },
 
@@ -137,7 +136,7 @@ simple_api_endpoints = {
             object_id = ^ca_objects.object_id,
             idno = ^ca_objects.idno,
             ItemName = ^ca_objects.preferred_labels,
-            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;CreatorType&quot;: &quot;^CreatorType&quot;", "&quot;Name&quot;: &quot;^Name&quot;</unit>"}]",
+            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^Name&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
             ErectedBy = ^ca_objects.ErectedBy,
             Location = "["<unit relativeTo="ca_places" delimiter="," returnAsArray="1"><unit relativeTo="ca_places.hierarchy"><unit>&quot;^ca_places.preferred_labels.name&quot;</unit></unit></unit>"]",
             Subjects = "["<unit relativeTo="ca_occurrences" delimiter="," restrictToTypes="subject">&quot;^preferred_labels&quot;</unit>"]"
@@ -154,13 +153,13 @@ simple_api_endpoints = {
             ItemName = ^ca_objects.preferred_labels,
             Description = ^ca_objects.Description,
             Inscription = ^ca_objects.Inscription,
-            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;CreatorType&quot;: &quot;^CreatorType&quot;", "&quot;Name&quot;: &quot;^Name&quot;</unit>"}]",
+            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^Name&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
             ErectedBy = ^ca_objects.ErectedBy,
             Location = "["<unit relativeTo="ca_places" delimiter=","><unit relativeTo="ca_places.hierarchy">&quot;^ca_places.preferred_labels.name&quot;</unit></unit>"]",
             Dates = ^ca_objects.Dates,
             Subjects = "["<unit relativeTo="ca_occurrences" delimiter="," restrictToTypes="subject">&quot;^preferred_labels&quot;</unit>"]",
             Materials = ^ca_objects.Materials,
-            Dimensions = "{"<unit relativeTo="ca_objects.Dimensions" delimiter=",">&quot;^DimensionsType&quot;: &quot;^DimensionsValue&quot;</unit>"}",
+            Dimensions = "[{"<unit relativeTo="ca_objects.Dimensions" delimiter="'},{'">&quot;Value&quot;: &quot;^DimensionsValue&quot;", "&quot;Type&quot;: &quot;^DimensionsType&quot;</unit>"}]",
             Provenance = ^ca_objects.Provenance
         }
     }


### PR DESCRIPTION
- Instead of a key-value object for `Dimensions` field return tuples of
  `DimensionValue` and `DimensionType`.
- Use the same keys (`Value` and `Type`) for both `Dimensions` and
  `Creator` so the frontend can use a single display component for both
  these fields.
- Also add missing `TermsOfUse` field.
