### PR TITLE
Add `all` search type, which returns the union of all search result fields

### DIFF
--- a/conf/services.conf
+++ b/conf/services.conf
@@ -1,5 +1,29 @@
 # Use Simple API to create endpoints for publicly accessible research frontend.
 simple_api_endpoints = {
+    # Search across collections
+    all_search = {
+        type = search,
+        table = ca_objects,
+        checkAccess = [ 1 ],
+        content = {
+            object_id = ^ca_objects.object_id,
+            type = ^type_id,
+            idno = ^ca_objects.idno,
+            ItemName = ^ca_objects.preferred_labels,
+            Title = ^ca_objects.preferred_labels,
+            Author = "["<unit relativeTo="ca_objects.Author" delimiter=",">&quot;^ca_objects.Author&quot;</unit>"]",
+            Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^CreatorName&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
+            DateOfCreation = ^ca_objects.DateOfCreation,
+            Publisher = ^ca_objects.Publisher,
+            DateOfPublication = ^ca_objects.DateOfPublication,
+            PlaceOfPublication = ^ca_objects.PlaceOfPublication,
+            PublicationType = ^ca_objects.PublicationType,
+            Location = "["<unit relativeTo="ca_places" delimiter="," returnAsArray="1"><unit relativeTo="ca_places.hierarchy"><unit>&quot;^ca_places.preferred_labels.name&quot;</unit></unit></unit>"]",
+            MediaThumbnail = ^ca_object_representations.media.thumbnail%returnURL=true,
+            MediaSmall = ^ca_object_representations.media.small%returnURL=true
+        }
+    },
+
     # Library
     library_search = {
         type = search,
@@ -8,6 +32,7 @@ simple_api_endpoints = {
         checkAccess = [ 1 ],
         content = {
             object_id = ^ca_objects.object_id,
+            type = ^type_id,
             idno = ^ca_objects.idno,
             Title = ^ca_objects.preferred_labels,
             Author = "["<unit relativeTo="ca_objects.Author" delimiter=",">&quot;^ca_objects.Author&quot;</unit>"]",
@@ -54,6 +79,7 @@ simple_api_endpoints = {
         checkAccess = [ 1 ],
         content = {
             object_id = ^ca_objects.object_id,
+            type = ^type_id,
             idno = ^ca_objects.idno,
             Title = ^ca_objects.preferred_labels,
             Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^CreatorName&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
@@ -97,12 +123,12 @@ simple_api_endpoints = {
         checkAccess = [ 1 ],
         content = {
             object_id = ^ca_objects.object_id,
+            type = ^type_id,
             idno = ^ca_objects.idno,
             type = ^type_id,
             ItemName = ^ca_objects.preferred_labels,
             ItemDates = ^ca_objects.ItemDates,
             Importance = ^ca_objects.Importance,
-            Classification = "[["<unit relativeTo="ca_list_items" delimiter="'],['"><unit relativeTo="ca_list_items.hierarchy" restrictToRelationshipTypes="described" delimiter=","><unit>&quot;^preferred_labels&quot;</unit></unit></unit>"]]",
             MediaThumbnail = ^ca_object_representations.media.thumbnail%returnURL=true,
             MediaSmall = ^ca_object_representations.media.small%returnURL=true
         }
@@ -140,6 +166,7 @@ simple_api_endpoints = {
         checkAccess = [ 1 ],
         content = {
             object_id = ^ca_objects.object_id,
+            type = ^type_id,
             idno = ^ca_objects.idno,
             ItemName = ^ca_objects.preferred_labels,
             Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^CreatorName&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",

--- a/conf/services.conf
+++ b/conf/services.conf
@@ -14,6 +14,7 @@ simple_api_endpoints = {
             Author = "["<unit relativeTo="ca_objects.Author" delimiter=",">&quot;^ca_objects.Author&quot;</unit>"]",
             Creator = "[{"<unit relativeTo="ca_objects.Creator" delimiter="'},{'">&quot;Value&quot;: &quot;^CreatorName&quot;", "&quot;Type&quot;: &quot;^CreatorType&quot;</unit>"}]",
             DateOfCreation = ^ca_objects.DateOfCreation,
+            MakersMarks = ^ca_objects.MakersMarks,
             Publisher = ^ca_objects.Publisher,
             DateOfPublication = ^ca_objects.DateOfPublication,
             PlaceOfPublication = ^ca_objects.PlaceOfPublication,
@@ -128,6 +129,7 @@ simple_api_endpoints = {
             type = ^type_id,
             ItemName = ^ca_objects.preferred_labels,
             ItemDates = ^ca_objects.ItemDates,
+            MakersMarks = ^ca_objects.MakersMarks,
             Importance = ^ca_objects.Importance,
             MediaThumbnail = ^ca_object_representations.media.thumbnail%returnURL=true,
             MediaSmall = ^ca_object_representations.media.small%returnURL=true


### PR DESCRIPTION
- Add `all` search endpoint.
- Add `type` to all search endpoints, so that the frontend can act consistently.
