### PR TITLE
Rwahs 275/add author access point

### DIFF
--- a/conf/search_indexing.conf
+++ b/conf/search_indexing.conf
@@ -111,6 +111,10 @@ ca_objects = {
 		subject = {
 			fields = [ca_occurrence_labels.name],
 			options = { }
+		},
+		author = {
+			fields = [ca_objects.Author],
+			options = { }
 		}
 	},
 	# ------------------------------------

--- a/conf/search_indexing.conf
+++ b/conf/search_indexing.conf
@@ -110,11 +110,13 @@ ca_objects = {
 		},
 		subject = {
 			fields = [ca_occurrence_labels.name],
-			options = { }
+			options = { },
+			name = _(Subject),
 		},
 		author = {
 			fields = [ca_objects.Author],
-			options = { }
+			options = { },
+			name = _(Author),
 		}
 	},
 	# ------------------------------------

--- a/conf/search_query_builder.conf
+++ b/conf/search_query_builder.conf
@@ -13,6 +13,7 @@ query_builder_global_options = {
 query_builder_priority_ca_objects = [
 	_fulltext,
 	ca_objects.idno,
+	subject,
 	ca_object_labels.name,
 	ca_objects.type_id,
 	ca_objects.status,
@@ -23,8 +24,7 @@ query_builder_priority_ca_objects = [
 	ca_objects.HistoricalDetails,
 	ca_objects.LibraryNumber,
 	ca_objects.MakersMarks,
-	ca_objects.Publisher,
-	ca_occurrence_labels.name
+	ca_objects.Publisher
 ]
 
 # Per-table list of field/filter names to exclude from the query builder.


### PR DESCRIPTION
Also add better label for `subject` access point, and use `subject` access point in search form instead of `ca_occurrence_labels.name`.

![subjectandauthoraccesspoints](https://cloud.githubusercontent.com/assets/12571/16868879/95c40fa8-4aac-11e6-8568-453df0a60b54.png)
