### PR TITLE
Add access points for 'has conservation record' and 'author'

### DIFF
--- a/conf/browse.conf
+++ b/conf/browse.conf
@@ -1,0 +1,266 @@
+# Configuration for object browse
+ca_objects = {
+	facets = {
+		title_facet = {
+			type = label,
+			restrict_to_types = [],
+			preferred_labels_only = 1,
+
+			group_mode = alphabetical,
+
+			label_singular = _("object title"),
+			label_plural = _("object titles")
+		},
+		violation_facet = {
+			type = violations,
+			restrict_to_types = [],
+			preferred_labels_only = 1,
+
+			#single_value = 1,
+			group_mode = none,
+
+			label_yes = _("Has problems"),
+			label_no = _("Does not have problems"),
+
+			label_singular = _("problem"),
+			label_plural = _("problems")
+		},
+		checkouts_facet = {
+			type = checkouts,
+			restrict_to_types = [],
+
+			# one of: user, all
+			#	user = show checkouts (type determined by 'status' below) by user
+			#	all = show types of checkouts in facet (in this case 'status' is not used)
+			mode = all,
+
+			# Limits facet to a specific type of checkout when mode is set to "user"
+			# one of: available, out, reserved, overdue
+			#
+			# If set when mode is "all" then the facet will only ever return matches for that status
+			#
+			#status = reserved,
+
+			group_mode = none,
+
+			label_singular = _("checkout"),
+			label_plural = _("checkouts")
+		},
+		deaccession_facet = {
+			type = field,
+			field = is_deaccessioned,
+			restrict_to_types = [],
+
+			group_mode = none,
+
+			#single_value = 1,
+
+			label_singular = _("deaccessioned"),
+			label_plural = _("deaccessioned")
+		},
+		has_media_facet = {
+			type = has,
+
+			table = ca_object_representations,
+			relationship_table = ca_objects_x_object_representations,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			#single_value = 1,
+			group_mode = none,
+
+			label_yes = _("Has media"),
+			label_no = _("Has no media"),
+
+			label_singular = _("has media"),
+			label_plural = _("has media")
+		},
+		entity_facet = {
+			# 'type' can equal authority, attribute, fieldList, normalizedDates
+			type = authority,
+			table = ca_entities,
+			relationship_table = ca_objects_x_entities,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+			individual_group_display = 0,
+
+			groupings = {
+				label = _("Name"),
+				type = _("Type"),
+				relationship_types = _("Role")
+			},
+			group_mode = alphabetical,
+			order_by_label_fields = [name_sort],
+
+			indefinite_article = an,
+			label_singular = _("entity"),
+			label_plural = _("entities")
+		},
+		place_facet = {
+			type = authority,
+			table = ca_places,
+			relationship_table = ca_objects_x_places,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			group_mode = hierarchical,
+
+			# Set to non-zero value to display hierarchy on items in this facet
+			show_hierarchy = 1,
+
+			# Character(s) to place between elements of the hierarchy
+			hierarchical_delimiter = &nbsp;⬅&nbsp;,
+
+			# Number of items to trim off the top (leave blank or set to 0 to trim nothing)
+			remove_first_items = ,
+
+			# Maximum length of hierarchy to display (leave blank to return hierarchy unabridged)
+			hierarchy_limit = 3,
+
+			# can be ASC or DESC (default is DESC)
+			hierarchy_order  = DESC,
+
+			label_singular = _("place"),
+			label_plural = _("places")
+		},
+		collection_facet = {
+			type = authority,
+			table = ca_collections,
+			relationship_table = ca_objects_x_collections,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			group_mode = alphabetical,
+
+			label_singular = _("collection"),
+			label_plural = _("collections")
+		},
+		occurrence_facet = {
+			type = authority,
+			table = ca_occurrences,
+			generate_facets_for_types = 1,
+			relationship_table = ca_objects_x_occurrences,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			groupings = {
+				label = _("Name"),
+				type = _("Type"),
+				relationship_types = _("Role"),
+				ca_attribute_dates_value:years = _("Years"),
+				ca_attribute_dates_value:decades = _("Decades")
+			},
+
+			group_mode = alphabetical,
+
+			label_singular = _("occurrence"),
+			label_plural = _("occurrences")
+		},
+		storage_location_facet = {
+			type = authority,
+			table = ca_storage_locations,
+			relationship_table = ca_objects_x_storage_locations,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			group_mode = hierarchical,
+
+			# Set to non-zero value to display hierarchy on items in this facet
+			show_hierarchy = 1,
+
+			# Character(s) to place between elements of the hierarchy
+			hierarchical_delimiter = &nbsp;⬅&nbsp;,
+
+			# Number of items to trim off the top
+			remove_first_items = 0,
+
+			# Maximum length of hierarchy to display
+			hierarchy_limit = 3,
+
+			# can be ASC or DESC
+			hierarchy_order  = DESC,
+
+			label_singular = _("storage location"),
+			label_plural = _("storage locations")
+		},
+		term_facet = {
+			type = authority,
+			table = ca_list_items,
+			relationship_table = ca_objects_x_vocabulary_terms,
+			restrict_to_types = [],
+			restrict_to_relationship_types = [],
+
+			group_mode = hierarchical,
+
+			# Set to non-zero value to display hierarchy on items in this facet
+			show_hierarchy = 1,
+
+			# Character(s) to place between elements of the hierarchy
+			hierarchical_delimiter = &nbsp; ⬅ &nbsp;,
+
+			# Number of items to trim off the top (leave blank or set to 0 to trim nothing)
+			remove_first_items = ,
+
+			# Maximum length of hierarchy to display (leave blank to return hierarchy unabridged)
+			hierarchy_limit = 3,
+
+			# can be ASC or DESC (default is DESC)
+			hierarchy_order  = DESC,
+
+			label_singular = _("term"),
+			label_plural = _("terms")
+		},
+		type_facet = {
+			type = fieldList,
+			field = type_id,
+
+			group_mode = none,
+			order_by_label_fields = [name_plural],
+
+			label_singular = _("type"),
+			label_plural = _("types")
+		},
+		status_facet = {
+			type = fieldList,
+			field = status,
+
+			group_mode = none,
+
+			label_singular = _("status"),
+			label_plural = _("statuses")
+		},
+		access_facet = {
+			type = fieldList,
+			field = access,
+
+			group_mode = none,
+
+			indefinite_article = an,
+			label_singular = _("access status"),
+			label_plural = _("access statuses")
+		},
+		year_facet = {
+			type = normalizedDates,
+			element_code = creation_date,
+			# 'normalization' can be: days, months, years, decades, centuries
+			normalization = years,
+
+			group_mode = none,
+			#single_value = 1950,
+
+			label_singular = _("year"),
+			label_plural = _("years")
+		},
+		decade_facet = {
+			type = normalizedDates,
+			element_code = creation_date,
+			# 'normalization' can be: days, months, years, decades, centuries
+			normalization = decades,
+
+			group_mode = none,
+
+			label_singular = _("decade"),
+			label_plural = _("decades")
+		}
+	}
+}

--- a/conf/browse.conf
+++ b/conf/browse.conf
@@ -278,6 +278,17 @@ ca_objects = {
 
 			label_singular = _("decade"),
 			label_plural = _("decades")
+		},
+		author_facet = {
+			type = attribute,
+			element_code = Author,
+			# 'normalization' can be: days, months, years, decades, centuries
+			normalization = decades,
+
+			group_mode = alphabetical,
+
+			label_singular = _("author"),
+			label_plural = _("authors")
 		}
 	}
 }

--- a/conf/browse.conf
+++ b/conf/browse.conf
@@ -75,6 +75,23 @@ ca_objects = {
 			label_singular = _("has media"),
 			label_plural = _("has media")
 		},
+		has_conservation_facet = {
+			type = has,
+
+			table = ca_occurrences,
+			relationship_table = ca_objects_x_occurrences,
+			restrict_to_types = [conservation],
+			restrict_to_relationship_types = [conservation],
+
+			#single_value = 1,
+			group_mode = none,
+
+			label_yes = _("Has conservation records"),
+			label_no = _("Has no conservation records"),
+
+			label_singular = _("has conservation record"),
+			label_plural = _("has conservation records")
+		},
 		entity_facet = {
 			# 'type' can equal authority, attribute, fieldList, normalizedDates
 			type = authority,


### PR DESCRIPTION
Fixes both RWAHS-317 and RWAHS-271.     06d4547

Easiest viewed as individual commits:
- Add default browse facets for `ca_objects` from core 06d4547
  - this is needed as this is a nested configuration item, and you have to override the full nested configuration :(
- Add browse facet for 'Has Conservation Record' b1aacc9
- Add author browse facet de23e90
## Results:

**Has Conservation Records**
![browsebyhasconservationrecords](https://cloud.githubusercontent.com/assets/12571/16905624/75d619a8-4cdb-11e6-8f32-06b7801a548b.png)

**Authors**
![browsebyauthorsandhasconservationrecords](https://cloud.githubusercontent.com/assets/12571/16905615/655955e0-4cdb-11e6-8f89-0b6ee7231729.png)
