### PR TITLE
Disable word stemming while search indexing

### DIFF
--- a/conf/search.conf
+++ b/conf/search.conf
@@ -1,0 +1,2 @@
+# See http://docs.collectiveaccess.org/wiki/Search.conf
+search_sql_search_do_stemming = 0


### PR DESCRIPTION
Fixes RWAHS-274.
- Default configuration - search for 'Jone'
  ![stemming](https://cloud.githubusercontent.com/assets/12571/16905824/d926a664-4cde-11e6-8873-e7e8c99921cc.png)
- With this change applied, now doesn't find the Jones record.
  ![stemmingremoved](https://cloud.githubusercontent.com/assets/12571/16905825/d927b3c4-4cde-11e6-841e-4e0287f62241.png)
- But you can still find the record when searching for `jones`
  ![butyoucanstillfindusingfullterm](https://cloud.githubusercontent.com/assets/12571/16905823/d9256fba-4cde-11e6-8e9c-79e182513698.png)
- And the also by using a wildcard
  ![andwildcard](https://cloud.githubusercontent.com/assets/12571/16905860/70756230-4cdf-11e6-89f5-6dd811f7082b.png)
