### PR TITLE
Configuration changes for item report

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -1,3 +1,9 @@
+# Theme configuration
+header_img = rwahs-logo-blue_print.png
+
+# Search Result Reporting configuration
+report_img = rwahs-logo-blue_print.png
+
 # Editor "disable" switches
 # If you're not using certain editors in your system
 ca_collections_disable = 1

--- a/conf/app.conf
+++ b/conf/app.conf
@@ -7,6 +7,10 @@ ca_object_lots_disable = 1
 # Media versions to provide downloads of
 ca_object_representation_download_versions = [original, "print-examination copy", "view copy", "view copy - multipage", "thumbnail copy"]
 
+# Summary printing page format
+
+summary_print_format = A4
+
 # Related item lookup settings
 ca_occurrences_lookup_settings = [^ca_occurrences.preferred_labels (^ca_occurrences.type_id)]
 ca_objects_lookup_settings = [<unit relativeTo='ca_objects'>^ca_object_representations.media.icon (^ca_objects.idno - ^ca_objects.type_id) ^ca_objects.preferred_labels</unit>]


### PR DESCRIPTION
The PDFs from https://github.com/rwahs/providence/pull/28 include the new logo and `summary_print_format`.
You can see the RWAHS logo instead of the CA one here:

![logo](https://cloud.githubusercontent.com/assets/12571/16941037/2de6139c-4dc0-11e6-969b-7c7730b70d56.png)
