### PR TITLE
Make subjects, entities and places all have incrementing integer identifiers

### DIFF
--- a/conf/multipart_id_numbering.conf
+++ b/conf/multipart_id_numbering.conf
@@ -260,14 +260,15 @@ formats = {
 	ca_entities = {
 		__default__ = {
 			separator =,
-			
 			elements = {
 				entity_number = {
-					type = FREE,
-					width = 30,
-					editable = 1,
-					
-					description = _(Identifier)
+					type = SERIAL,
+					width = 6,
+					description = _(Entity Identifier),
+					editable = 0,
+					table = ca_entities,
+					field = idno,
+					sort_field = idno_sort
 				}
 			}
 		}
@@ -276,14 +277,15 @@ formats = {
 	ca_places = {
 		__default__ = {
 			separator =,
-			
 			elements = {
 				place_number = {
-					type = FREE,
-					width = 30,
-					editable = 1,
-					
-					description = _(Identifier)
+					type = SERIAL,
+					width = 6,
+					description = _(Place Identifier),
+					editable = 0,
+					table = ca_places,
+					field = idno,
+					sort_field = idno_sort
 				}
 			}
 		}
@@ -310,6 +312,20 @@ formats = {
 					type = SERIAL,
 					width = 6,
 					description = _(Conservation Identifier),
+					editable = 0,
+					table = ca_occurrences,
+					field = idno,
+					sort_field = idno_sort
+				}
+			}
+		},
+		Subject = {
+			separator =,
+			elements = {
+				subject_number = {
+					type = SERIAL,
+					width = 6,
+					description = _(Subject Identifier),
 					editable = 0,
 					table = ca_occurrences,
 					field = idno,

--- a/conf/multipart_id_numbering.conf
+++ b/conf/multipart_id_numbering.conf
@@ -373,11 +373,13 @@ formats = {
 			
 			elements = {
 				representation_number = {
-					type = FREE,
-					width = 30,
-					editable = 1,
-					
-					description = _(Identifier)
+					type = SERIAL,
+					width = 6,
+					description = _(Representation Identifier),
+					editable = 0,
+					table = ca_object_representations,
+					field = idno,
+					sort_field = idno_sort
 				}
 			}
 		}


### PR DESCRIPTION
RWAHS-476

I realised that the source fields that are mapped into the idno fields for these record types are incrementing integer values, so this just means the client will not have to create these values. This is not configurable via the UI so I thought it should go in above some of the other form changes
