### PR TITLE
Endpoint for sitemap

### DIFF
--- a/conf/services.conf
+++ b/conf/services.conf
@@ -214,8 +214,7 @@ simple_api_endpoints = {
     	checkAccess = [ 1 ],
     	content = {
     		object_id = ^ca_objects.object_id,
-    		type = ^type_id,
-    		PageTitle = ^ca_objects.preferred_labels
+    		type = ^type_id
     	}
     }
 }

--- a/conf/services.conf
+++ b/conf/services.conf
@@ -205,5 +205,17 @@ simple_api_endpoints = {
             MediaMedium = <unit relativeTo="ca_object_representations"><if rule=\"^access =~ /^accessible to public$/\">^media.medium%returnURL=true</if></unit>,
             MediaAccess = <unit relativeTo="ca_object_representations"><if rule=\"^access =~ /^accessible to public$/\">true</if><if rule=\"^access !~ /^accessible to public$/\">false</if></unit>
         }
+    },
+
+    # Search endpoint for generation of sitemap
+    sitemap_search = {
+    	type = search,
+    	table = ca_objects,
+    	checkAccess = [ 1 ],
+    	content = {
+    		object_id = ^ca_objects.object_id,
+    		type = ^type_id,
+    		PageTitle = ^ca_objects.preferred_labels
+    	}
     }
 }


### PR DESCRIPTION
Includes #43 and #44, please merge them first.

Creates an endpoint that returns the data required for building a sitemap for the research frontend, as per RWAHS-447.
