### PR TITLE
Allow movement permissions to be available

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -11,6 +11,8 @@ ca_collections_disable = 1
 ca_object_lots_disable = 1
 # Allow users to browse representations
 ca_object_representations_disable = 0
+# Allow movement permissions to be available
+ca_movements_disable = 0
 
 # Stop users being able create a representation without a parent record
 ca_object_representations_dont_show_in_new_menu = 1


### PR DESCRIPTION
- In order for cataloguers to be able to add a movement to update the location, movements need to be enabled.
  - this allows the action can_quickadd_ca_movements to be available through role permissions
  - Also requires setting of movement type access for the role
- RWAHS-500
  ![before](https://cloud.githubusercontent.com/assets/12571/17764659/60ce7b82-6553-11e6-9fe9-33a5cdadaec3.png)
  ![after](https://cloud.githubusercontent.com/assets/12571/17764661/64592554-6553-11e6-9f34-521734ed4df8.png)
