### PR TITLE
RWAHS-628 Move Creator Name into frequently used fields

### DIFF
--- a/conf/search_query_builder.conf
+++ b/conf/search_query_builder.conf
@@ -17,7 +17,7 @@ query_builder_priority_ca_objects = [
 	ca_objects.type_id,
 	ca_objects.Author,
 	classification,
-	creator,
+	ca_objects.Creator.CreatorName,
 	ca_objects.CurrentLocation,
 	ca_objects.DateOfPublication,
 	donor,


### PR DESCRIPTION
![creatorname](https://cloud.githubusercontent.com/assets/12571/18735987/eac35278-80b4-11e6-9c5c-2d502a8b312b.png)
- we are no longer using the `creator` access point.
